### PR TITLE
Use npm start instead of npx webpack and modify README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # webpack-boilerplate
-This is a boilerplate to start a JS project with Webpack and Bable.
+
+> Boilerplate for JS project with the use of Webpack and Babel.
+
+## Built With
+
+- HTML5
+- CSS3
+- JavaScript
+- Webpack
+
+## Getting Started
+
+To get a local copy up and running follow these simple example steps.
+
+### Prerequisites
+
+- Node.js
+
+### Setup
+
+<p>Clone this repo either by typing `git clone https://github.com/martinnajjar12/webpack-boilerplate.git` (You must have git installed on your local machine in this case) or download a zip version of the code from GitHub.</p>
+
+<p>Instal the dependencies with:</p>
+
+```
+  npm install
+```
+
+### Usage
+
+Compile the code by typing the following command in your terminal (Make sure your in the root directory of your project):
+
+```
+  npm start
+```
+
+Now double-click `index.html` which is in the `dist` folder to open it in your browser.
+
+## Author: Martin Najjar
+
+- Github: [@martinnajjar12](https://github.com/martinnajjar12)
+- Twitter: [@martin_najjar](https://twitter.com/martin_najjar)
+- LinkedIn: [Martin Najjar](https://www.linkedin.com/in/martinnajjar12/)
+
+## 🤝 Contributing
+
+Contributions, issues and feature requests are welcome!
+
+Feel free to check the [issues page](https://github.com/martinnajjar12/webpack-boilerplate/issues).
+
+## Show your support
+
+Give a ⭐️ if you like this project!
+
+## Acknowledgments
+
+Martin Najjar 😁.
+
+### 📝 License
+
+This project is [MIT](https://github.com/martinnajjar12/webpack-boilerplate/blob/development/LICENSE) licensed.

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -10,6 +10,6 @@
 /*!**********************!*\
   !*** ./src/index.js ***!
   \**********************/
-eval("alert('Hello, World!');\n\n\n//# sourceURL=webpack://webpack-boilerplate/./src/index.js?");
+eval("alert(\"I'm a new text\");\r\n\n\n//# sourceURL=webpack://webpack-boilerplate/./src/index.js?");
 /******/ })()
 ;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This is a boilerplate to start a JS project with Webpack and Bable.",
   "main": "index.js",
   "scripts": {
+    "start": "webpack --watch --mode development",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-alert('Hello, World!');
+alert("I'm a new text");


### PR DESCRIPTION
In this branch I used `npm start` instead of `npx webpack --mode development` and modified `README.md` file